### PR TITLE
Fix typos

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -517,7 +517,7 @@ librenms__nginx__dependent_upstreams:
 librenms__nginx__dependent_servers:
  -  by_role: 'debops.librenms'
     type: 'php'
-    name: '{{ librenms__fqdn }}'
+    name: [ '{{ librenms__fqdn }}' ]
     root: '{{ librenms__install_path + "/html" }}'
     filename: 'debops.librenms'
     access_policy: '{{ librenms__nginx_access_policy }}'

--- a/docs/playbooks/librenms.yml
+++ b/docs/playbooks/librenms.yml
@@ -23,7 +23,7 @@
       tags: [ 'role::logrotate' ]
       logrotate__dependent_config:
         - '{{ php__logrotate__dependent_config }}'
-        - '{{ librenms__logrotate__dependent_config }]'
+        - '{{ librenms__logrotate__dependent_config }}'
 
     - role: debops.ferm
       tags: [ 'role::ferm' ]


### PR DESCRIPTION
The bracket instead of brace issue exists in   debops-playbooks too.  Should I make it a PR of its own ?

```
commit d61490185b9e38dd83bb63188c9433986d0c64e9
Author: Alban Browaeys <alban.browaeys@gmail.com>
Date:   Thu Sep 8 05:14:52 2016 +0200

	Fix typo : bracket instead of curly brace in librenms play.

diff --git a/playbooks/service/librenms.yml b/playbooks/service/librenms.yml
index fd50cad..28f4bc9 100644
--- a/playbooks/service/librenms.yml
+++ b/playbooks/service/librenms.yml
@@ -23,7 +23,7 @@
	   tags: [ 'role::logrotate' ]
	   logrotate__dependent_config:
		 - ' php__logrotate__dependent_config '
-        - '{{ librenmslogrotatedependent_config }]'
+        - ' librenms__logrotate__dependent_config '
 
	 - role: debops.ferm
	   tags: [ 'role::ferm' ]
```